### PR TITLE
Solved issue of ArgsTable not displaying subcomponent props. Applied …

### DIFF
--- a/src/components/Alert/AlertBody.tsx
+++ b/src/components/Alert/AlertBody.tsx
@@ -13,6 +13,4 @@ const AlertBody = ({ children, className = '', ...rest }: AlertBodyProps) => (
   </div>
 );
 
-AlertBody.displayName = 'Alert.Body';
-
 export default AlertBody;

--- a/src/components/Alert/AlertHeader.tsx
+++ b/src/components/Alert/AlertHeader.tsx
@@ -22,6 +22,4 @@ const AlertHeader = ({
   </Title>
 );
 
-AlertHeader.displayName = 'Alert.Header';
-
 export default AlertHeader;

--- a/src/components/Alert/AlertLink.tsx
+++ b/src/components/Alert/AlertLink.tsx
@@ -16,6 +16,4 @@ const AlertLink = ({ children, className = '', ...rest }: AlertLinkProps) => (
   </a>
 );
 
-AlertLink.displayName = 'Alert.Link';
-
 export default AlertLink;

--- a/src/components/Form/FormCheck.tsx
+++ b/src/components/Form/FormCheck.tsx
@@ -92,6 +92,4 @@ const FormCheck = React.forwardRef(
   }
 );
 
-FormCheck.displayName = 'Form.Check';
-
 export default FormCheck;

--- a/src/components/Form/FormCheckGroup.tsx
+++ b/src/components/Form/FormCheckGroup.tsx
@@ -35,6 +35,4 @@ const FormCheckGroup = ({
   );
 };
 
-FormCheckGroup.displayName = 'Form.CheckGroup';
-
 export default FormCheckGroup;

--- a/src/components/Form/FormControl.tsx
+++ b/src/components/Form/FormControl.tsx
@@ -123,6 +123,4 @@ const FormControl = React.forwardRef(
   }
 );
 
-FormControl.displayName = 'Form.Control';
-
 export default FormControl;

--- a/src/components/Form/FormGroup.tsx
+++ b/src/components/Form/FormGroup.tsx
@@ -42,6 +42,4 @@ const FormGroup = ({
   );
 };
 
-FormGroup.displayName = 'Form.Group';
-
 export default FormGroup;

--- a/src/components/Form/FormLabel.tsx
+++ b/src/components/Form/FormLabel.tsx
@@ -56,6 +56,4 @@ const FormLabel = ({
   );
 };
 
-FormLabel.displayName = 'Form.Label';
-
 export default FormLabel;

--- a/src/components/Form/FormSelect.tsx
+++ b/src/components/Form/FormSelect.tsx
@@ -70,6 +70,4 @@ const FormSelect = React.forwardRef(
   }
 );
 
-FormSelect.displayName = 'Form.Select';
-
 export default FormSelect;

--- a/src/components/Form/FormText.tsx
+++ b/src/components/Form/FormText.tsx
@@ -23,6 +23,4 @@ const FormText = ({
   </FormRB.Text>
 );
 
-FormText.displayName = 'Form.Text';
-
 export default FormText;

--- a/src/components/Form/stories/Form.check.group.stories.mdx
+++ b/src/components/Form/stories/Form.check.group.stories.mdx
@@ -1,8 +1,14 @@
-import { Story, Canvas, Meta } from '@storybook/addon-docs';
+import { Story, Canvas, Meta, ArgsTable } from '@storybook/addon-docs';
 
 import { Form } from '../..';
 
-<Meta title="Components/Form/Form Check Group" component={Form} />
+<Meta
+  title="Components/Form/Form Check Group"
+  component={Form}
+  subcomponents={{
+    'Form.CheckGroup': Form.CheckGroup,
+  }}
+/>
 
 # Forms
 
@@ -125,17 +131,4 @@ You can set a custom "required" text
 
 ### Form.CheckGroup Props
 
-**We are working to display the props in a table. Until then, you can find the props below:**
-
-```typescript
-export interface FormCheckProps {
-  /** Content of form label */
-  children?: React.ReactNode;
-  /** label attribute */
-  label?: React.ReactNode;
-  /** Allows for the customization of "required" label. It is helpful for translations. Default: "required" */
-  requiredText?: React.ReactNode;
-  /** Additional custom classNames */
-  className?: string;
-}
-```
+<ArgsTable of={Form.CheckGroup} />

--- a/src/components/Form/stories/Form.check.stories.mdx
+++ b/src/components/Form/stories/Form.check.stories.mdx
@@ -1,8 +1,14 @@
-import { Story, Canvas, Meta } from '@storybook/addon-docs';
+import { Story, Canvas, Meta, ArgsTable } from '@storybook/addon-docs';
 
 import { Form } from '../..';
 
-<Meta title="Components/Form/Form Check" component={Form} />
+<Meta
+  title="Components/Form/Form Check"
+  component={Form}
+  subcomponents={{
+    'Form.Check': Form.Check,
+  }}
+/>
 
 # Forms
 
@@ -142,31 +148,4 @@ The `<Form.Check>` component accepts all of the default props for the `check` HT
 More info about the HTML element:<br/>
 https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement
 
-**We are working to display the props in a table. Until then, you can find the props below:**
-
-```typescript
-export interface FormCheckProps {
-  /** label attribute */
-  label?: React.ReactNode;
-  /** The HTML input type, which is only relevant if as is 'input' (the default). */
-  type?: typeType;
-  /** Make the control disabled. */
-  isDisabled?: boolean;
-  /** Groups controls horizontally with other <Form.Checks>. */
-  isInline?: boolean;
-  /** Add "aria-invalid="true" to input */
-  isInvalid?: boolean;
-  /** Is field required */
-  isRequired?: boolean;
-  /** Show the "required styling" for the field */
-  showRequiredStyling?: boolean;
-  /** Allows for the customization of "required" label. It is helpful for translations. Default: "required" */
-  requiredText?: string;
-  /** Uses controlId from <FormGroup> if not explicitly specified. */
-  id?: string;
-  /** Name of form field. */
-  name?: string;
-  /** Additional custom classNames */
-  className?: string;
-}
-```
+<ArgsTable of={Form.Check} />

--- a/src/components/Form/stories/Form.control.stories.mdx
+++ b/src/components/Form/stories/Form.control.stories.mdx
@@ -1,8 +1,14 @@
-import { Story, Canvas, Meta } from '@storybook/addon-docs';
+import { Story, Canvas, Meta, ArgsTable } from '@storybook/addon-docs';
 
 import { Form } from '../..';
 
-<Meta title="Components/Form/Form Control" component={Form} />
+<Meta
+  title="Components/Form/Form Control"
+  component={Form}
+  subcomponents={{
+    'Form.Control': Form.Control,
+  }}
+/>
 
 # Forms
 
@@ -202,33 +208,4 @@ The `min` and `max` props can be used to restrict numbers in a number field.
 
 ### Form.Control Props
 
-**We are working to display the props in a table. Until then, you can find the props below:**
-
-```typescript
-export interface FormControlProps {
-  /** Placeholder content */
-  placeholder?: string;
-  /** The underlying HTML element to use when rendering the FormControl. */
-  as?: asType;
-  /** The HTML input type, which is only relevant if as is 'input' (the default). */
-  type?: typeType;
-  /** Make the control disabled. */
-  isDisabled?: boolean;
-  /** Make the control readonly. */
-  isReadOnly?: boolean;
-  /** Add "aria-invalid="true" to input */
-  isInvalid?: boolean;
-  /** Add "aria-required="true" to input */
-  isRequired?: boolean;
-  /** The size attribute of the underlying HTML element. Specifies the visible width in characters if as is 'input'. */
-  htmlSize?: number;
-  /** Input size variants: 'default', 'sm', 'lg' */
-  size?: sizeType;
-  /** A callback fired when the value prop changes */
-  onChange;
-  /** Uses controlId from <FormGroup> if not explicitly specified. */
-  id?: string;
-  /** Additional custom classNames */
-  className?: string;
-}
-```
+<ArgsTable of={Form.Control} />

--- a/src/components/Form/stories/Form.intro.stories.mdx
+++ b/src/components/Form/stories/Form.intro.stories.mdx
@@ -2,7 +2,19 @@ import { ArgsTable, Canvas, Meta } from '@storybook/addon-docs';
 
 import { Form, Button } from '../..';
 
-<Meta title="Components/Form/Intro" component={Form} />
+<Meta
+  title="Components/Form/Intro"
+  component={Form}
+  subcomponents={{
+    'Form.Check': Form.Check,
+    'Form.CheckGroup': Form.CheckGroup,
+    'Form.Control': Form.Control,
+    'Form.Group': Form.Group,
+    'Form.Label': Form.Label,
+    'Form.Select': Form.Select,
+    'Form.Text': Form.Text,
+  }}
+/>
 
 # Forms
 
@@ -37,8 +49,6 @@ The `<Form>` component accepts all of the default props for the `form` HTML elem
 More info about the HTML element:<br/>
 https://developer.mozilla.org/en-US/docs/Web/API/HTMLFormElement
 
-<ArgsTable />
-
 ## Form Props
 
 Form elements can be wrapped with a `<Form.Group>` component. This allows us to group the `label` with the form controls.
@@ -47,17 +57,4 @@ Form elements can be wrapped with a `<Form.Group>` component. This allows us to 
 
 Available props can be seen below.
 
-````
-{
-  /** Content of group */
-  children?: React.ReactNode;
-  /** Unique Id of form group elements */
-  controlId?: string;
-  /** Additional custom classNames */
-  className?: string;
-  /** Applies 'required' styling to form group elements */
-  isRequired?: boolean;
-  /** Sets whether form input is valid */
-  isInvalid?: boolean;
-}```
-````
+<ArgsTable />

--- a/src/components/Form/stories/Form.label.stories.mdx
+++ b/src/components/Form/stories/Form.label.stories.mdx
@@ -1,8 +1,14 @@
-import { Story, Canvas, Meta } from '@storybook/addon-docs';
+import { Story, Canvas, Meta, ArgsTable } from '@storybook/addon-docs';
 
 import { Form } from '../..';
 
-<Meta title="Components/Form/Form Label" component={Form} />
+<Meta
+  title="Components/Form/Form Label"
+  component={Form}
+  subcomponents={{
+    'Form.Label': Form.Label,
+  }}
+/>
 
 # Forms
 
@@ -53,25 +59,4 @@ Hides the label visually while still allowing it to be read by assistive technol
 
 ### Form.Label Props
 
-**We are working to display the props in a table. Until then, you can find the props below:**
-
-```typescript
-export interface FormLabelProps {
-  /** Content of form label */
-  children?: React.ReactNode;
-  /** Set a custom element for this component */
-  as?: React.ElementType;
-  /** Uses controlId from <FormGroup> if not explicitly specified. */
-  htmlFor?: string;
-  /** Hides the label visually while still allowing it to be read by assistive technologies */
-  isVisuallyHidden?: boolean;
-  /** Applies 'require' styling to form label */
-  isRequired?: boolean;
-  /** Show the "required styling" for the field */
-  showRequiredStyling?: boolean;
-  /** Allows for the customization of "required" label. It is helpful for translations. Default: "required" */
-  requiredText?: React.ReactNode;
-  /** Additional custom classNames */
-  className?: string;
-}
-```
+<ArgsTable of={Form.Label} />

--- a/src/components/Form/stories/Form.select.stories.mdx
+++ b/src/components/Form/stories/Form.select.stories.mdx
@@ -1,8 +1,14 @@
-import { Story, Canvas, Meta } from '@storybook/addon-docs';
+import { Story, Canvas, Meta, ArgsTable } from '@storybook/addon-docs';
 
 import { Form } from '../..';
 
-<Meta title="Components/Form/Form Select" component={Form} />
+<Meta
+  title="Components/Form/Form Select"
+  component={Form}
+  subcomponents={{
+    'Form.Select': Form.Select,
+  }}
+/>
 
 # Forms
 
@@ -71,29 +77,4 @@ The `<Form.Select>` component accepts all of the default props for the `select` 
 More info about the HTML element:<br/>
 https://developer.mozilla.org/en-US/docs/Web/API/HTMLSelectElement
 
-**We are working to display the props in a table. Until then, you can find the props below:**
-
-```typescript
-export interface FormSelectProps {
-  /** Content of button */
-  children?: React.ReactNode;
-  /** Placeholder content */
-  placeholder?: string;
-  /** Make the control disabled. */
-  isDisabled?: boolean;
-  /** Add "aria-invalid="true" to input */
-  isInvalid?: boolean;
-  /** Add "aria-required="true" to input */
-  isRequired?: boolean;
-  /** The size attribute of the underlying HTML element. Specifies the number of visible options. */
-  htmlSize?: number;
-  /** Input size variants: 'default', 'sm', 'lg' */
-  size?: sizeType;
-  /** A callback fired when the value prop changes */
-  onChange;
-  /** Uses controlId from <Form.Group> if not explicitly specified. */
-  id?: string;
-  /** Additional custom classNames */
-  className?: string;
-}
-```
+<ArgsTable of={Form.Select} />

--- a/src/components/Form/stories/Form.text.stories.mdx
+++ b/src/components/Form/stories/Form.text.stories.mdx
@@ -1,8 +1,14 @@
-import { Story, Canvas, Meta } from '@storybook/addon-docs';
+import { Story, Canvas, Meta, ArgsTable } from '@storybook/addon-docs';
 
 import { Form, Alert } from '../..';
 
-<Meta title="Components/Form/Form Text" component={Form} />
+<Meta
+  title="Components/Form/Form Text"
+  component={Form}
+  subcomponents={{
+    'Form.Text': Form.Text,
+  }}
+/>
 
 # Forms
 
@@ -65,19 +71,6 @@ The `isMuted` prop can be used to mute the text styling. It defaults to `true`.
   </Story>
 </Canvas>
 
-### Form.Text Props
+Available props can be seen below.
 
-**We are working to display the props in a table. Until then, you can find the props below:**
-
-```typescript
-export interface FormTextProps {
-  /** Content of button */
-  children?: React.ReactNode;
-  /** A convenience prop for add the text-muted class, since it's so commonly used here. */
-  isMuted?: boolean;
-  /** Hides the label visually while still allowing it to be read by assistive technologies */
-  visuallyHidden?: boolean;
-  /** Additional custom classNames */
-  className?: string;
-}
-```
+<ArgsTable of={Form.Text} />

--- a/src/components/InputGroup/InputGroupText.tsx
+++ b/src/components/InputGroup/InputGroupText.tsx
@@ -23,6 +23,4 @@ const InputGroupText = ({
   </span>
 );
 
-InputGroupText.displayName = 'InputGroup.Text';
-
 export default InputGroupText;

--- a/src/components/InputGroup/stories/InputGroup.intro.stories.mdx
+++ b/src/components/InputGroup/stories/InputGroup.intro.stories.mdx
@@ -3,7 +3,13 @@ import { ArgsTable, Canvas, Meta, Story } from '@storybook/addon-docs';
 import InputGroup from '../InputGroup';
 import Form from 'src/components/Form/index.ts';
 
-<Meta title="Components/InputGroup/Intro" component={InputGroup} />
+<Meta
+  title="Components/InputGroup/Intro"
+  component={InputGroup}
+  subcomponents={{
+    'InputGroup.Text': InputGroup.Text,
+  }}
+/>
 
 # Input Group
 

--- a/src/components/ListGroup/ListGroupItem.tsx
+++ b/src/components/ListGroup/ListGroupItem.tsx
@@ -41,6 +41,5 @@ const ListGroupItem = ({
     {children}
   </ListGroupRB.Item>
 );
-ListGroupItem.displayName = 'ListGroup.Item';
 
 export default ListGroupItem;

--- a/src/components/Modal/ModalBody.tsx
+++ b/src/components/Modal/ModalBody.tsx
@@ -9,5 +9,5 @@ export interface ModalBodyProps extends React.HTMLAttributes<HTMLDivElement> {
 const ModalBody = ({ children, ...rest }: ModalBodyProps) => (
   <ModalBodyRB {...rest}>{React.Children.toArray(children)}</ModalBodyRB>
 );
-ModalBody.displayName = 'Modal.Body';
+
 export default ModalBody;

--- a/src/components/Modal/ModalDialog.tsx
+++ b/src/components/Modal/ModalDialog.tsx
@@ -42,5 +42,5 @@ const ModalDialog = ({
     {React.Children.toArray(children)}
   </ModalRB>
 );
-ModalDialog.displayName = 'ModalDialog';
+
 export default ModalDialog;

--- a/src/components/Modal/ModalFooter.tsx
+++ b/src/components/Modal/ModalFooter.tsx
@@ -10,5 +10,5 @@ export interface ModalFooterProps extends React.HTMLAttributes<HTMLDivElement> {
 const ModalFooter = ({ children, ...rest }: ModalFooterProps) => (
   <ModalFooterRB {...rest}>{React.Children.toArray(children)}</ModalFooterRB>
 );
-ModalFooter.displayName = 'Modal.Footer';
+
 export default ModalFooter;

--- a/src/components/Modal/ModalHeader.tsx
+++ b/src/components/Modal/ModalHeader.tsx
@@ -20,6 +20,4 @@ const ModalHeader = ({
   </ModalHeaderRB>
 );
 
-ModalHeader.displayName = 'Modal.Header';
-
 export default ModalHeader;

--- a/src/components/Modal/ModalTitle.tsx
+++ b/src/components/Modal/ModalTitle.tsx
@@ -10,6 +10,4 @@ const ModalTitle = ({ children, ...rest }: ModalTitleProps) => (
   <ModalTitleRB {...rest}>{React.Children.toArray(children)}</ModalTitleRB>
 );
 
-ModalTitle.displayName = 'Modal.Title';
-
 export default ModalTitle;

--- a/src/components/Modal/stories/Modal.intro.stories.mdx
+++ b/src/components/Modal/stories/Modal.intro.stories.mdx
@@ -2,7 +2,17 @@ import { ArgsTable, Canvas, Meta } from '@storybook/addon-docs';
 
 import { Modal } from '../..';
 
-<Meta title="Components/Modal/Intro" component={Modal} />
+<Meta
+  title="Components/Modal/Intro"
+  component={Modal}
+  subcomponents={{
+    'Modal.Body': Modal.Body,
+    'Modal.Dialog': Modal.Dialog,
+    'Modal.Footer': Modal.Footer,
+    'Modal.Header': Modal.Header,
+    'Modal.Title': Modal.Title,
+  }}
+/>
 
 # Modal
 

--- a/src/components/Table/TableBody.tsx
+++ b/src/components/Table/TableBody.tsx
@@ -15,6 +15,4 @@ const TableBody = ({ children, className, ...rest }: TableBodyProps) => (
   </tbody>
 );
 
-TableBody.displayName = 'Table.Body';
-
 export default TableBody;

--- a/src/components/Table/TableCell.tsx
+++ b/src/components/Table/TableCell.tsx
@@ -31,6 +31,4 @@ const TableCell = ({
   </td>
 );
 
-TableCell.displayName = 'Table.Cell';
-
 export default TableCell;

--- a/src/components/Table/TableHeader.tsx
+++ b/src/components/Table/TableHeader.tsx
@@ -31,6 +31,4 @@ const TableHeader = ({
   </thead>
 );
 
-TableHeader.displayName = 'Table.Header';
-
 export default TableHeader;

--- a/src/components/Table/TableRow.tsx
+++ b/src/components/Table/TableRow.tsx
@@ -31,6 +31,4 @@ const TableRow = ({
   </tr>
 );
 
-TableRow.displayName = 'Table.Row';
-
 export default TableRow;

--- a/src/components/Table/stories/Table.intro.stories.mdx
+++ b/src/components/Table/stories/Table.intro.stories.mdx
@@ -2,7 +2,16 @@ import { ArgsTable, Canvas, Meta } from '@storybook/addon-docs';
 
 import { Table } from '../..';
 
-<Meta title="Components/Table/Intro" component={Table} />
+<Meta
+  title="Components/Table/Intro"
+  component={Table}
+  subcomponents={{
+    'Table.Body': Table.Body,
+    'Table.Cell': Table.Cell,
+    'Table.Header': Table.Header,
+    'Table.Row': Table.Row,
+  }}
+/>
 
 # Table
 


### PR DESCRIPTION
…fix to Alert, Form, InputGroup, Modal, ListGroup, Table. Fix to InputGroup is partially on InputGroupText.tsx, which was also altered in the Alex-FixRepoErrors branch. The two changes are compatible with each other, as they apply to different parts of the document. Also fixed the Form component stories, they were old and lacking stuff, notably had no ArgsTable so the props were hardcoded.

⭐ **New Features:**

- description of feature 1
- description of feature 2

ℹ️ **Related Issues:**

resolves _[add ticket reference]_

📷 **Screenshots:** _(if applicable)_
