### PR TITLE
[Fix] Fixed "TypeError: (0 , _css.default) is not a function" error

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -2,7 +2,7 @@ module.exports = {
   testEnvironment: 'jsdom',
   setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
   moduleNameMapper: {
-    '.(css|less|scss)$': 'identity-obj-proxy',
+    '\\.(css|less|scss)$': 'identity-obj-proxy',
     '^@components(.*)$': '<rootDir>/src/components$1',
   },
   coverageThreshold: {


### PR DESCRIPTION
⭐ **New Features:**

Fixed `TypeError: (0 , _css.default) is not a function` error.

ℹ️ **Related Issues:**
Closes #26 

📷 **Screenshots:** _(if applicable)_
Example of a failing test before implementing the fix:
![image](https://user-images.githubusercontent.com/46769064/171068087-1227dfdb-623c-42f0-88aa-b2b1910448f2.png)

Example of the test passing after implementing the fix:
![image](https://user-images.githubusercontent.com/46769064/171068206-fd3f2be7-bbb2-4936-bb3e-529cdd9cc7fa.png)
