### PR TITLE
[Fix] Fixed regeneratorRuntime is not defined error

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,6 +1,6 @@
 module.exports = {
   presets: [
-    '@babel/preset-env',
+    ['@babel/preset-env', { targets: { node: 'current' } }],
     '@babel/preset-react',
     '@babel/preset-typescript',
   ],


### PR DESCRIPTION
⭐ **New Features:**
Fixed `ReferenceError: regeneratorRuntime is not defined` error.

ℹ️ **Related Issues:**
#28 

📷 **Screenshots:** _(if applicable)_
Example of a failing test before implementing the fix:
![image](https://user-images.githubusercontent.com/46769064/171069381-20b5204d-eb67-4c4f-bd49-647a2e1c5fca.png)

Example of the test passing after implementing the fix:
![image](https://user-images.githubusercontent.com/46769064/171069370-93d04ba3-5729-4fd7-a6a6-dad83a95b57b.png)
